### PR TITLE
:sparkles: User can favorite a Highline

### DIFF
--- a/mobile/src/hooks/useIsFavorite.tsx
+++ b/mobile/src/hooks/useIsFavorite.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 import { HeartOutlinedSvg, HeartFilledSvg } from '@src/assets';
 
+import { trpc } from '@src/utils/trpc';
+
 type UseIsFavorite = [React.FC<HeartStyledProps>, () => void];
 
 interface HeartStyledProps {
@@ -8,13 +10,32 @@ interface HeartStyledProps {
   strokeWidth?: number; // default 1
 }
 
-function useIsFavorite(initialValue = false): UseIsFavorite {
-  const [isFavorite, setIsFavorite] = useState<boolean>(initialValue);
+function useIsFavorite(highlineId: string): UseIsFavorite {
+  const [isFavorite, setIsFavorite] = useState<boolean | null>(null);
+
+  const { refetch, isFetching } = trpc.highline.checkIsFavorited.useQuery(
+    { highlineId },
+    {
+      onSuccess: (data) => setIsFavorite(!!data),
+    }
+  );
+
+  const favoriteMutation = trpc.highline.favorite.useMutation({
+    onSuccess: () => refetch(),
+  });
+
+  const unfavoriteMutation = trpc.highline.unfavorite.useMutation({
+    onSuccess: () => refetch(),
+  });
 
   const toggleFavorite = useCallback(() => {
-    // TODO: Integrate with API
-    setIsFavorite((prev) => !prev);
-  }, []);
+    if (isFetching) return;
+    if (isFavorite) {
+      unfavoriteMutation.mutate({ highlineId });
+    } else {
+      favoriteMutation.mutate({ highlineId });
+    }
+  }, [isFavorite, isFetching]);
 
   const HeartIcon: React.FC<HeartStyledProps> = ({ strokeColor, strokeWidth }) => {
     return (

--- a/mobile/src/hooks/useProfile.ts
+++ b/mobile/src/hooks/useProfile.ts
@@ -4,16 +4,16 @@ import { useAuth } from '@clerk/clerk-expo';
 import { trpc } from '@src/utils/trpc';
 
 export const useProfile = () => {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth();
 
-  const { data, isLoading, mutate } = trpc.auth.upsertProfile.useMutation({});
+  const profileMutation = trpc.auth.upsertProfile.useMutation({});
 
   useEffect(() => {
     if (isSignedIn) {
       // When user Log in, create user profile if it doesn't exist
-      mutate();
+      profileMutation.mutate();
     }
   }, [isSignedIn]);
 
-  return { data, isLoading };
+  return { profile: profileMutation.data, isLoaded: !profileMutation.isLoading && isLoaded };
 };

--- a/mobile/src/hooks/useProfile.ts
+++ b/mobile/src/hooks/useProfile.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useAuth } from '@clerk/clerk-expo';
+
+import { trpc } from '@src/utils/trpc';
+
+export const useProfile = () => {
+  const { isSignedIn } = useAuth();
+
+  const { data, isLoading, mutate } = trpc.auth.upsertProfile.useMutation({});
+
+  useEffect(() => {
+    if (isSignedIn) {
+      // When user Log in, create user profile if it doesn't exist
+      mutate();
+    }
+  }, [isSignedIn]);
+
+  return { data, isLoading };
+};

--- a/mobile/src/navigation/index.tsx
+++ b/mobile/src/navigation/index.tsx
@@ -7,9 +7,9 @@ import RootRoutes from './app.routes';
 import AuthRoutes from './auth.routes';
 
 const Routes: React.FC = () => {
-  const { data, isLoading } = useProfile();
+  const { profile, isLoaded } = useProfile();
 
-  if (isLoading) {
+  if (!isLoaded) {
     return (
       <View className="flex flex-1 items-center justify-center">
         <ActivityIndicator size="large" color="#666" />
@@ -17,7 +17,7 @@ const Routes: React.FC = () => {
     );
   }
 
-  return data ? <RootRoutes /> : <AuthRoutes />;
+  return profile ? <RootRoutes /> : <AuthRoutes />;
 };
 
 export default Routes;

--- a/mobile/src/navigation/index.tsx
+++ b/mobile/src/navigation/index.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { View, ActivityIndicator } from 'react-native';
 
-import { useAuth } from '@clerk/clerk-expo';
+import { useProfile } from '@src/hooks/useProfile';
 
 import RootRoutes from './app.routes';
 import AuthRoutes from './auth.routes';
 
 const Routes: React.FC = () => {
-  const { isLoaded, isSignedIn } = useAuth();
+  const { data, isLoading } = useProfile();
 
-  if (!isLoaded) {
+  if (isLoading) {
     return (
       <View className="flex flex-1 items-center justify-center">
         <ActivityIndicator size="large" color="#666" />
@@ -17,7 +17,7 @@ const Routes: React.FC = () => {
     );
   }
 
-  return isSignedIn ? <RootRoutes /> : <AuthRoutes />;
+  return data ? <RootRoutes /> : <AuthRoutes />;
 };
 
 export default Routes;

--- a/mobile/src/screens/DetailScreen/DetailScreen.tsx
+++ b/mobile/src/screens/DetailScreen/DetailScreen.tsx
@@ -16,7 +16,11 @@ const DetailScreen = ({ navigation, route }: DetailScreenProps) => {
 
   return (
     <ScrollView className="flex flex-1">
-      <ImageHeader isRigged={highline.isRigged} goBack={() => navigation.goBack()} />
+      <ImageHeader
+        isRigged={highline.isRigged}
+        goBack={() => navigation.goBack()}
+        highlineId={highline.uuid}
+      />
       <View className="mx-2">
         <Text className="text-2xl font-extrabold">{highline.name}</Text>
         <FirstCadena />

--- a/mobile/src/screens/DetailScreen/components/ImageHeader.tsx
+++ b/mobile/src/screens/DetailScreen/components/ImageHeader.tsx
@@ -6,13 +6,13 @@ import { ShareSvg, ArrowLeftSvg } from '@src/assets';
 import useIsFavorite from '@src/hooks/useIsFavorite';
 
 interface Props {
+  highlineId: string;
   isRigged?: boolean;
   goBack: () => void;
 }
 
-const ImageHeader = ({ isRigged, goBack }: Props) => {
-  const isFavorite = false;
-  const [HeartSvg, toggleFavorite] = useIsFavorite(isFavorite);
+const ImageHeader = ({ highlineId, isRigged, goBack }: Props) => {
+  const [HeartSvg, toggleFavorite] = useIsFavorite(highlineId);
 
   return (
     <ImageBackground

--- a/mobile/src/screens/Map/HomeScreen/components/Card/DetailCard/DetailCard.tsx
+++ b/mobile/src/screens/Map/HomeScreen/components/Card/DetailCard/DetailCard.tsx
@@ -32,7 +32,7 @@ interface Props {
 const DetailCard = ({ highlitedMarker, navigation }: Props) => {
   const dispatch = useAppDispatch();
   const { updateStorageWithNewHighline } = useLastHighline();
-  const [HeartSvg, toggleFavorite] = useIsFavorite(false);
+  const [HeartSvg, toggleFavorite] = useIsFavorite(highlitedMarker.id);
 
   const { data: highline, isFetchedAfterMount } = trpc.highline.getById.useQuery(
     highlitedMarker.id

--- a/server/api/src/router/auth.ts
+++ b/server/api/src/router/auth.ts
@@ -1,0 +1,11 @@
+import { router, protectedProcedure } from "../trpc";
+
+export const authRouter = router({
+  upsertProfile: protectedProcedure.mutation(async ({ ctx }) => {
+    return await ctx.prisma?.profile.upsert({
+      where: { clerkUserId: ctx.userId },
+      update: {},
+      create: { clerkUserId: ctx.userId },
+    });
+  }),
+});

--- a/server/api/src/router/index.ts
+++ b/server/api/src/router/index.ts
@@ -1,10 +1,12 @@
 import { router } from "../trpc";
 import { markerRouter } from "./marker";
 import { highlineRouter } from "./highline";
+import { authRouter } from "./auth";
 
 export const appRouter = router({
   marker: markerRouter,
   highline: highlineRouter,
+  auth: authRouter,
 });
 
 // export type definition of API

--- a/server/prisma/migrations/20230413213452_chooselife/migration.sql
+++ b/server/prisma/migrations/20230413213452_chooselife/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "Profile" (
+    "clerkUserId" TEXT NOT NULL,
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("clerkUserId")
+);
+
+-- CreateTable
+CREATE TABLE "FavoritedHighline" (
+    "profileId" TEXT NOT NULL,
+    "highlineId" TEXT NOT NULL,
+
+    CONSTRAINT "FavoritedHighline_pkey" PRIMARY KEY ("profileId","highlineId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_clerkUserId_key" ON "Profile"("clerkUserId");
+
+-- AddForeignKey
+ALTER TABLE "FavoritedHighline" ADD CONSTRAINT "FavoritedHighline_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("clerkUserId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FavoritedHighline" ADD CONSTRAINT "FavoritedHighline_highlineId_fkey" FOREIGN KEY ("highlineId") REFERENCES "Highline"("uuid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -11,6 +11,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Profile {
+  clerkUserId       String              @id @unique
+  favoriteHighlines FavoritedHighline[]
+}
+
 model HighlineAnchor {
   uuid        String     @id @default(uuid())
   description String
@@ -22,12 +27,22 @@ model HighlineAnchor {
 }
 
 model Highline {
-  uuid     String           @id @default(uuid())
-  name     String
-  height   Int
-  length   Int
-  isRigged Boolean
-  anchors  HighlineAnchor[]
+  uuid          String              @id @default(uuid())
+  name          String
+  height        Int
+  length        Int
+  isRigged      Boolean
+  anchors       HighlineAnchor[]
+  isFavoritedBy FavoritedHighline[]
+}
+
+model FavoritedHighline {
+  profileId  String
+  profile    Profile  @relation(fields: [profileId], references: [clerkUserId], onDelete: Cascade)
+  highlineId String
+  highline   Highline @relation(fields: [highlineId], references: [uuid], onDelete: Cascade)
+
+  @@id([profileId, highlineId])
 }
 
 enum AnchorSide {


### PR DESCRIPTION
## What is the purpose of this PR
Integrate the functionality of favoriting a Highline with the database

## What was done to achieve
Create a table `Profile` that refers to the ClerkUser on the system DB. It can be used to extend Clerk information.
Create a table `FavoritedHighline` that relates a Highline with a Profile in a many-to-many relationship.

Check for the user Profile when it logs in (use the Clerk hook to get that info) and create it if doesn't exist.

Implemented the toggleFavorite function with two mutations, one for creating and another for deleting the `FavoritedHighline` instante.
 

## How to test if it works?
On the map screen, click on a marker.
Favorite it and check if the heart turns red
Fling the card up, go to the details screens, and check if the favorite state persists.
Unfavorite it
Go back
Check if the state persisted
